### PR TITLE
Menu label typo

### DIFF
--- a/server/FormCMS/wwwroot/schema-ui/json/menu.json
+++ b/server/FormCMS/wwwroot/schema-ui/json/menu.json
@@ -56,7 +56,7 @@
           },
           "label": {
             "title": "Label",
-            "description": "Manu Label",
+            "description": "Menu Label",
             "minLength": 1,
             "type": "string"
           },


### PR DESCRIPTION
`Manu label` typo when you edit menu items : 

![image](https://github.com/user-attachments/assets/51ffc1d9-4a10-42d7-a6cd-4cdfd0a4d511)
